### PR TITLE
chore: Add npm install to npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # pollifi
+
+## How to run the application
+Write `npm run dev`into the terminal

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "npm install && vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
## Related issues
Issue #7 

# Summary
Add `npm install` to `npm run dev` command in  package.json. Having to write only one command rather than two makes things less of a hassle. 

# What has been done?
See above

# Checklist of necessary prerequesits

- [x] The definition of done has been reatched
- [x] My changes generate no new warnings
- [x] I have added comments to code where needed
- [x] I have tested that there are no new bugs
- [x] All tests passes
- [ ] The cicd pipline has succeeded *Optional before pipeline is implemented*
- [x] I have made corresponding changes to the documentation
