### PR TITLE
fix: Split emulator start command from run dev

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "npm install && firebase emulators:start --project=pollify & vite --mode development",
+    "dev": "npm install && vite --mode development",
     "build": "tsc -b && vite build --mode production",
     "lint": "eslint .",
     "preview": "vite preview",
-    "emulators": "firebase emulators:start"
+    "emulators": "firebase emulators:start --project=pollify"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.2",


### PR DESCRIPTION
## Related issues
Issue #

# Summary
`"dev": "npm install && firebase emulators:start --project=pollify & vite --mode development"` will only start up the emulators,
`"dev": "npm install && vite --mode development && firebase emulators:start --project=pollify"` will only start up the website dev server.

To mitigate we split up the start up of the emulator suite for firebase and the start up of the dev website server into two commands. Now we have:

`"dev": "npm install && vite --mode development",` and `"emulators": "firebase emulators:start --project=pollify"`
which each have to be run in their own separate terminal.


# What has been done?
see above

# Checklist of necessary prerequesits

- [x] The definition of done has been reatched
- [x] My changes generate no new warnings
- [x] I have added comments to code where needed
- [x] I have tested that there are no new bugs
- [ ] All tests passes
- [ ] The cicd pipline has succeeded *Optional before pipeline is implemented*
- [ ] I have made corresponding changes to the documentation
